### PR TITLE
Refresh upstream fit validation

### DIFF
--- a/docs/UPSTREAM-FIT.md
+++ b/docs/UPSTREAM-FIT.md
@@ -16,6 +16,23 @@ This project is most credible to `pingdotgg/t3code` when it stays narrow and rel
 - WebView-based access can still be handled with disciplined security defaults and visible error handling.
 - Small self-hosted tools benefit from observability too: copyable diagnostics in the app and a health endpoint in proxy mode make support and triage much faster.
 
+## Current Validation
+
+Last checked: 2026-05-05 on `main` after the ESLint 10 and Node runtime update in
+[`JSvandijk/t3code-mobile#19`](https://github.com/JSvandijk/t3code-mobile/pull/19).
+
+- `npm test` passes from a clean local checkout after `npm ci`.
+- JavaScript syntax checks pass.
+- ESLint 10 flat-config linting passes with no warnings.
+- `manifest.json` validation passes.
+- Release checks pass for version `1.1.0`.
+- HTML unit tests pass: 18/18.
+- Proxy smoke test passes, including HTML injection, static assets, and `GET /__t3mobile/health`.
+- `cmd /c build-apk.bat` builds a dev-signed APK successfully.
+
+The current upstream discussion is tracked in
+[`pingdotgg/t3code#2514`](https://github.com/pingdotgg/t3code/issues/2514).
+
 ## Good Upstream-Friendly Change Shapes
 
 - Small reliability fixes


### PR DESCRIPTION
## Summary

Refreshes `docs/UPSTREAM-FIT.md` with current validation data and links to the upstream T3 discussion.

## Why

`pingdotgg/t3code#2514` links directly to this document, so it should show current evidence instead of only describing the intended positioning.

## Verification

Ran locally after `npm install`:

- `npm test` passed
- JS syntax checks passed
- ESLint passed
- `manifest.json` check passed
- release checks passed for version 1.1.0
- HTML tests passed: 18/18
- proxy smoke test passed